### PR TITLE
Fix code scanning alert no. 832: Potential use after free

### DIFF
--- a/deps/openssl/openssl/ssl/statem/extensions_clnt.c
+++ b/deps/openssl/openssl/ssl/statem/extensions_clnt.c
@@ -1662,6 +1662,11 @@ int tls_parse_stoc_alpn(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
     }
     s->s3.alpn_selected_len = len;
 
+    if (s->s3.alpn_selected == NULL) {
+        SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+        return 0;
+    }
+
     if (s->session->ext.alpn_selected == NULL
             || s->session->ext.alpn_selected_len != len
             || s->s3.alpn_selected == NULL


### PR DESCRIPTION
Fixes [https://github.com/akaday/node/security/code-scanning/832](https://github.com/akaday/node/security/code-scanning/832)

To fix the potential use-after-free error, we need to ensure that `s->s3.alpn_selected` is not used after it has been freed unless it has been successfully reassigned. This involves adding checks to ensure that the pointer is not `NULL` before it is used. Specifically, we should add a check after the memory allocation at line 1653 to ensure that the pointer is not `NULL` before proceeding with any operations that use it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
